### PR TITLE
fix: 🐛 Export `PolymeshTypesBundle` to fix ts declaration error

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import rpc from './rpc';
 import signedExtensions from './signedExtensions';
 import types from './types';
 
-interface PolymeshTypesBundle {
+export interface PolymeshTypesBundle {
   spec: Record<string, OverrideBundleDefinition>;
 }
 


### PR DESCRIPTION
When importing `typesBundle` from this package, it used to give the error `Default export of the module has or is using private name 'PolymeshTypesBundle'.ts`. Exporting the type get rids of the error.