### PR TITLE
fix: 🐛 fix AssetCount RPC types

### DIFF
--- a/src/types/6.1.x.json
+++ b/src/types/6.1.x.json
@@ -1215,9 +1215,9 @@
     "error": "Option<String>"
   },
   "AssetCount": {
-    "fungible_tokens": "u32",
-    "non_fungible_tokens": "u32",
-    "off_chain_assets": "u32"
+    "fungible": "u32",
+    "non_fungible": "u32",
+    "off_chain": "u32"
   },
   "AffirmationCount": {
     "sender_asset_count": "AssetCount",


### PR DESCRIPTION
AssetCount RPC types do not have "_tokens" suffix