### PR TITLE
fix: 🐛use correct case for `NFTApi` runtime api

### DIFF
--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -7,8 +7,8 @@ import { ComplianceApiV2 } from './complianceApi/v2';
 import { GroupApiV1 } from './groupApi/v1';
 import { IdentityApiV3 } from './identityApi/v3';
 import { IdentityApiV4 } from './identityApi/v4';
-import { NftApiV1 } from './nftApi/v1';
-import { NftApiV2 } from './nftApi/v2';
+import { NFTApiV1 } from './nftApi/v1';
+import { NFTApiV2 } from './nftApi/v2';
 import { PipsApiV1 } from './pipsApi/v1';
 import { ProtocolApiV1 } from './protocolApi/v1';
 import { SettlementApiV1 } from './settlementApi/v1';
@@ -29,9 +29,9 @@ export const runtime: DefinitionsCall = {
     { methods: IdentityApiV4, version: 4 },
     { methods: IdentityApiV3, version: 3 },
   ],
-  NftApi: [
-    { methods: NftApiV2, version: 2 },
-    { methods: NftApiV1, version: 1 },
+  NFTApi: [
+    { methods: NFTApiV2, version: 2 },
+    { methods: NFTApiV1, version: 1 },
   ],
   PipsApi: [{ methods: PipsApiV1, version: 1 }],
   ProtocolFeeApi: [{ methods: ProtocolApiV1, version: 1 }],

--- a/src/runtime/nftApi/v1.ts
+++ b/src/runtime/nftApi/v1.ts
@@ -1,6 +1,6 @@
 import { DefinitionCall } from '@polkadot/types/types';
 
-export const NftApiV1: Record<string, DefinitionCall> = {
+export const NFTApiV1: Record<string, DefinitionCall> = {
   validate_nft_transfer: {
     description:
       'Verifies if and the sender and receiver are not the same, if both have valid balances, if the sender owns the nft, and if all compliance rules are being respected.',

--- a/src/runtime/nftApi/v2.ts
+++ b/src/runtime/nftApi/v2.ts
@@ -1,6 +1,6 @@
 import { DefinitionCall } from '@polkadot/types/types';
 
-export const NftApiV2: Record<string, DefinitionCall> = {
+export const NFTApiV2: Record<string, DefinitionCall> = {
   transfer_report: {
     description:
       "Returns a vector containing all errors for the transfer. An empty vec means there's no error.",


### PR DESCRIPTION
### Description

the NFT runtime API should be `NFTApi` not `NftApi`.

### Breaking Changes

N/A

### JIRA Link

N/A

### Checklist

- [ ] Updated the Readme.md (if required) ?
