### PR TITLE
ci: Changing the action to use trusted publishing for npm packages

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: [lint]
     if: github.event_name == 'push'
+    permissions:
+      contents: write       # push release commits, tags, create GitHub Releases
+      issues: write         # @semantic-release/github comments on resolved issues
+      pull-requests: write  # @semantic-release/github comments on merged PRs
+      id-token: write       # OIDC token for npm trusted publishing
     steps:
       - uses: actions/checkout@v4
       - name: Enable Corepack
@@ -53,7 +58,6 @@ jobs:
       - name: release
         env:
           GITHUB_TOKEN: ${{ secrets.ASSOCIATION_RELEASE_TOKEN }}
-          NPM_TOKEN: ${{ secrets.ASSOCIATION_NPM_TOKEN }}
         run: |
           cd dist
           yarn --immutable


### PR DESCRIPTION
### Description

Migrate npm publishing from classic token authentication to OIDC Trusted Publishing.

npm classic tokens were permanently revoked in December 2025. Granular access tokens
are now limited to 90 days for write access, requiring periodic manual rotation.

OIDC Trusted Publishing eliminates token management entirely — GitHub provides
short-lived tokens automatically via its OIDC provider.

Changes:
- Remove `NPM_TOKEN` secret from release workflow
- Add `id-token: write` permission to enable OIDC token generation
- Add explicit `contents`, `issues`, and `pull-requests` permissions (previously implicit)

### Breaking Changes

<!-- List all the breaking changes here -->

### JIRA Link

<!-- Insert JIRA issue here. Example: DA-40  -->

### Checklist

- [ ] Updated the Readme.md (if required) ?
